### PR TITLE
security: 修复 workspace 端点残留 4 处路径穿越（CodeQL sink 净化）

### DIFF
--- a/server.py
+++ b/server.py
@@ -488,8 +488,15 @@ async def create_workspace(path: str = Form(...), name: str = Form("")):
             detail="工作目录路径不合法或超出允许范围（可由 AGNES_WORKSPACE_ROOT 环境变量放宽）",
         )
     entry = add_workspace(safe_path, name.strip())
-    os.makedirs(entry["path"], exist_ok=True)
-    os.makedirs(os.path.join(entry["path"], "uploads"), exist_ok=True)
+    # Path-injection hardening: re-validate the *resolved* path stays within the
+    # allowed workspace root before any disk write. The sink must use the
+    # containment-checked value, not the raw stored entry["path"].
+    ws_root = os.path.realpath(os.environ.get("AGNES_WORKSPACE_ROOT") or os.path.expanduser("~"))
+    entry_real = os.path.realpath(entry["path"])
+    if entry_real != ws_root and not entry_real.startswith(ws_root + os.sep):
+        raise HTTPException(status_code=422, detail="工作目录路径超出允许范围")
+    os.makedirs(entry_real, exist_ok=True)
+    os.makedirs(os.path.join(entry_real, "uploads"), exist_ok=True)
     return {"ok": True, "workspace": entry, "active_workspace": get_active_workspace()}
 
 
@@ -519,8 +526,14 @@ async def activate_workspace(path: str = Form(...)):
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    os.makedirs(active, exist_ok=True)
-    os.makedirs(os.path.join(active, "uploads"), exist_ok=True)
+    # Path-injection hardening: re-validate the *resolved* path stays within the
+    # allowed workspace root before any disk write (sink must use the checked value).
+    ws_root = os.path.realpath(os.environ.get("AGNES_WORKSPACE_ROOT") or os.path.expanduser("~"))
+    active_real = os.path.realpath(active)
+    if active_real != ws_root and not active_real.startswith(ws_root + os.sep):
+        raise HTTPException(status_code=422, detail="工作目录路径超出允许范围")
+    os.makedirs(active_real, exist_ok=True)
+    os.makedirs(os.path.join(active_real, "uploads"), exist_ok=True)
     return {"ok": True, "active_workspace": active}
 
 


### PR DESCRIPTION
## 概述
首轮 PR #21 合并后，GitHub 代码扫描仍有 **4 处 `py/path-injection`** 未清除（#9、#10、#11、#12，位于 `server.py:491-492` 与 `522-523` 的 `os.makedirs`）。

## 根因
首轮修复在 `create_workspace` / `activate_workspace` **入口**用 `safe_workspace_path` 校验了用户输入，但落盘 **sink** 用的是 `add_workspace` / `set_active_workspace` 的**返回值**（`entry["path"]` / `active`）。CodeQL 无法跨函数证明该返回值等于已净化的输入，因此仍判定污点流入 `os.makedirs`。

## 修复
在 sink 处对**实际落盘路径**做内联 `os.path.realpath` + 受信任根 `startswith` containment 检查（与首轮已验证清掉的 `serve_artifact_file` 模式完全一致），确保流入 `os.makedirs` 的路径经过净化再使用。

## 验证
本 PR 触发默认 code scanning，请确认合并前 #9-#12 共 4 个 alert 全部清除、仓库 open alert 归零。