### PR TITLE
docs: 更新 .env.example 多 key 配置示例（5-key + 国内站地址）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,13 @@
 # ═══════════════════════════════════════════════════════════════════
 
 
-# ── 1. API Key（必填）──────────────────────────────────────────────
+# ── 1. API Key（必填，多 key 时保留 KEY_1，额外 key 往后累加）──
 # 从 https://platform.agnes-ai.com 获取免费 Key
-AGNES_API_KEY=your-api-key-here
+AGNES_API_KEY_1=your-api-key-here
+AGNES_API_KEY_2=your-second-api-key
+AGNES_API_KEY_3=your-third-api-key
+AGNES_API_KEY_4=your-fourth-api-key
+AGNES_API_KEY_5=your-fifth-api-key
 
 
 # ── 2. 多 Key 轮询（可选，推荐）────────────────────────────────────
@@ -26,9 +30,13 @@ AGNES_API_KEY=your-api-key-here
 # 遇到 429 会自动轮换到下一个 Key；限速配额与并发上限随 Key 数线性放大。
 # AGNES_API_KEY_2=your-second-api-key
 # AGNES_API_KEY_3=your-third-api-key
+# AGNES_API_KEY_4=your-fourth-api-key
+# AGNES_API_KEY_5=your-fifth-api-key
 
 
 # ── 3. 服务地址 ────────────────────────────────────────────────────
+# 国内站（非必需，缺省用国际站 https://apihub.agnes-ai.com/v1）
+# AGNES_BASE_URL=https://api.agnes-ai.cn/v1
 HOST=0.0.0.0
 PORT=8765
 


### PR DESCRIPTION
## 更新内容

- Section 1: `AGNES_API_KEY` → `AGNES_API_KEY_1~5` 格式，支持 5-key 轮询
- Section 2: 多 key 注释扩展到 5 个
- Section 3: 增加 `AGNES_BASE_URL` 国内站地址说明

## 背景

5 个 key 轮询需要明确示例格式，避免用户误填导致 key 加载失败。